### PR TITLE
Drop alchemist gem dependency

### DIFF
--- a/knife-xenserver.gemspec
+++ b/knife-xenserver.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |s|
   ## Fog 1.3.1 deps. We'll need to remove them
   # when using fog upstream
   s.add_dependency('colored')
-  s.add_dependency('alchemist')
   s.add_dependency('uuidtools')
   s.require_paths = ["lib"]
 end

--- a/lib/chef/knife/xenserver_base.rb
+++ b/lib/chef/knife/xenserver_base.rb
@@ -33,7 +33,6 @@ class Chef
             require 'readline'
             require 'chef/json_compat'
             require 'terminal-table/import'
-            require 'alchemist'
           end
 
           option :xenserver_password,
@@ -90,6 +89,10 @@ class Chef
       def locate_config_value(key)
         key = key.to_sym
         Chef::Config[:knife][key] || config[key]
+      end
+
+      def bytes_to_megabytes(bytes)
+        (bytes.to_i / (1024.0 * 1024.0)).round
       end
 
     end

--- a/lib/chef/knife/xenserver_template_list.rb
+++ b/lib/chef/knife/xenserver_template_list.rb
@@ -53,7 +53,7 @@ class Chef
               networks << name
             end
             networks = networks.join("\n")
-            mem = vm.memory_static_max.to_i.bytes.to.megabytes.round
+            mem = bytes_to_megabytes(vm.memory_static_max)
             t << ["#{vm.name}\n  #{ui.color('uuid: ', :yellow)}#{vm.uuid}", mem, vm.tools_installed?, networks]
           end
         end

--- a/lib/chef/knife/xenserver_vm_list.rb
+++ b/lib/chef/knife/xenserver_vm_list.rb
@@ -119,7 +119,7 @@ class Chef
             networks << name
           end
           row << networks
-          row << vm.memory_static_max.to_i.bytes.to.megabytes.round
+          row << bytes_to_megabytes(vm.memory_static_max)
           row << vm.power_state
           row << vm.tools_installed?
           table << row


### PR DESCRIPTION
Seems like [Alchemist](https://github.com/halogenandtoast/alchemist) gem (knife-xenserver uses it to convert bytes to megabytes) is the only reason that knife-xenserver does not work on ruby 1.9 .

cc Hi @rubiojr , my ultimate goal was being able to use knife-xenserver. Since we have already fixed https://github.com/fog/fog/issues/1335, I am testing knife-xenserver.

**Update**: I just rebased the branch
