### PR TITLE
fixed utilization calculation. 

### DIFF
--- a/lib/chef/knife/xenserver_sr_list.rb
+++ b/lib/chef/knife/xenserver_sr_list.rb
@@ -55,7 +55,7 @@ class Chef
               utilisation = sr.physical_utilisation
             else
               if sr.physical_size.to_i > 0
-                utilisation = (sr.physical_utilisation.to_i * 100)/sr.physical_size.to_f * 100
+                utilisation = (sr.physical_utilisation.to_i * 100)/sr.physical_size.to_f
                 utilisation = "%.2f%" % utilisation
               else
                 utilisation = "100%"


### PR DESCRIPTION
Utilization report of the SRs were off by 2 decimal places. Removed the \* 100 to sr.physical_size.to_f in order to line up the SR utilization numbers with XenCenter utilization.
