### PR TITLE
Update xenserver_vm_create.rb added param -j, --json-attributes

### DIFF
--- a/lib/chef/knife/xenserver_vm_create.rb
+++ b/lib/chef/knife/xenserver_vm_create.rb
@@ -85,6 +85,13 @@ class Chef
         :description => "Comma separated list of roles/recipes to apply",
         :proc => lambda { |o| o.split(/[\s,]+/) },
         :default => []
+        
+      option :first_boot_attributes,
+        :short => "-j JSON_ATTRIBS",
+        :long => "--json-attributes",
+        :description => "A JSON string to be added to the first run of chef-client",
+        :proc => lambda { |o| JSON.parse(o) },
+        :default => {}
 
       option :ssh_user,
         :short => "-x USERNAME",
@@ -325,6 +332,7 @@ class Chef
         bootstrap = Chef::Knife::Bootstrap.new
         bootstrap.name_args = [@ssh_ip]
         bootstrap.config[:run_list] = config[:run_list]
+        bootstrap.config[:first_boot_attributes] = config[:first_boot_attributes]
         bootstrap.config[:ssh_user] = config[:ssh_user] 
         bootstrap.config[:identity_file] = config[:identity_file]
         bootstrap.config[:chef_node_name] = config[:chef_node_name] || vm.name


### PR DESCRIPTION
Added ability to pass attributes. Example:

```
knife xenserver vm create --xenserver-host $HOST --xenserver-password $PASS --vm-name $NAME --vm-ip $IP --vm-netmask $MASK --vm-gateway $GATE --vm-dns 8.8.8.8 --vm-template centos-cloudtechlab --keep-template-networks --ssh-password cl0udAdmin ssh-user root --distro chef-full --vm-memory 2048 -r $COOKBOOK::$RECIPE -j '{"creds":{"admin_password":"cl0udAdmin","mysql_password":"cl0udAdmin","ssh_keypair":"openstack"},"ip":{"qpid":"192.168.251.10","keystone":"192.168.251.11","swift":"192.168.251.12","glance":"192.168.251.13","cinder":"192.168.251.14","quantum":"192.168.251.15","nova":"192.168.251.16","heat":"192.168.251.17"}}'
```
